### PR TITLE
use https

### DIFF
--- a/wp2git.py
+++ b/wp2git.py
@@ -51,15 +51,15 @@ def main():
 
     # Connect to site with mwclient
     if args.site is not None:
-        scheme, host, path = urlparse.urlparse(args.site, scheme='http')[:3]
+        scheme, host, path = urlparse.urlparse(args.site, scheme='https')[:3]
         if path=='':
             path = '/w/'
         elif not path.endswith('/'):
             path += '/'
     elif args.lang is not None:
-        scheme, host, path = 'http', '%s.wikipedia.org' % args.lang, '/w/'
+        scheme, host, path = 'https', '%s.wikipedia.org' % args.lang, '/w/'
     else:
-        scheme, host, path = 'http', 'wikipedia.org', '/w/'
+        scheme, host, path = 'https', 'wikipedia.org', '/w/'
     site = mwclient.Site((scheme, host), path=path)
     print('Connected to %s://%s%s' % (scheme, host, path), file=stderr)
 


### PR DESCRIPTION
Need to use https otherwise it gives error 

```
requests.exceptions.HTTPError: 403 Client Error: Insecure Request Forbidden - use HTTPS - https://lists.wikimedia.org/pipermail/mediawiki-api-announce/2016-May/000110.html for url:
```
