### PR TITLE
Fix error handling for nonexistent pages

### DIFF
--- a/wp2git/wp2git.py
+++ b/wp2git/wp2git.py
@@ -68,7 +68,7 @@ def main():
     # Find the page
     page = site.pages[args.article_name]
     if not page.exists:
-        p.error('Page %s does not exist' % s)
+        p.error('Page %s does not exist' % args.article_name)
     fn = sanitize(args.article_name)
 
     if args.doimport:


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File ".../wp2git", line 9, in <module>
    load_entry_point('wp2git==1.0.1', 'console_scripts', 'wp2git')()
  File ".../site-packages/wp2git/wp2git.py", line 71, in main
    p.error('Page %s does not exist' % s)
NameError: global name 's' is not defined
```

Found using pyflakes.