### PR TITLE
Don't require userid to be set

### DIFF
--- a/wp2git/wp2git.py
+++ b/wp2git/wp2git.py
@@ -100,7 +100,7 @@ def main():
             tags = (['minor'] if 'minor' in rev else []) + [tag.encode('utf8') for tag in rev['tags']]
             ts = time.mktime(rev['timestamp'])
 
-            if rev['userid']:
+            if rev.get('userid'):
                 committer = '%s <%s@%s>' % (user,user_,host)
             else:
                 committer = '%s <>' % user


### PR DESCRIPTION
Fixes:

```console
$ wp2git --lang en Adblock_Plus
...
>> Minor Revision 233246255 by Clarityfiend at Thu Aug 21 03:17:46 2008: minor tweak
Traceback (most recent call last):
  File ".../bin/wp2git", line 11, in <module>
    load_entry_point('wp2git==1.0.1.dev4+gb519d2d', 'console_scripts', 'wp2git')()
  File ".../lib/python2.7/site-packages/wp2git/wp2git.py", line 103, in main
    if rev['userid']:
KeyError: 'userid'
fatal: stream ends early
fast-import: dumping crash report to .git/fast_import_crash_11328
```